### PR TITLE
Add a check to determine if token is renewable before trying to renew.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
     image: vault
     cap_add:
       - IPC_LOCK
+    ports:
+        - "28200:8200"
     environment:
       VAULT_DEV_ROOT_TOKEN_ID: test_token
 

--- a/main.go
+++ b/main.go
@@ -62,6 +62,17 @@ func main() {
 	// Renew the token periodically (half of every lease duration), starting
 	// right now.
 	go func() {
+		renewable, err := GetVaultTokenRenewable(config)
+
+		if err != nil {
+			log.Printf("error determining renewable token: %s", err)
+			return
+		}
+
+		if !renewable {
+			return
+		}
+
 		leaseTimeout := 0 * time.Second
 		for {
 			time.Sleep(leaseTimeout * time.Second)

--- a/main.go
+++ b/main.go
@@ -13,7 +13,6 @@ import (
 func errCheck(err error) {
 	if err != nil {
 		log.Fatal(err)
-		os.Exit(1)
 	}
 }
 
@@ -90,6 +89,4 @@ func main() {
 	// This is a blocking call that runs several go-funcs to manage sending
 	// signals to the process.
 	errCheck(RunWithEnvVars(cmd, vaultSecrets))
-
-	os.Exit(0)
 }


### PR DESCRIPTION
Before this change, the app would try to renew any token it was given (and after failing once, would stop trying to renew it).  This produced a benign error in the logs, and also would send a vault service an unnecessary failing request.

This change first checks to see if the token is renewable, and if not, does not attempt to renew the token.